### PR TITLE
Fix: Image links

### DIFF
--- a/packages/katana/components/KatanaVaultItem.tsx
+++ b/packages/katana/components/KatanaVaultItem.tsx
@@ -305,8 +305,8 @@ export const VaultItem = ({vault, price, options, apr}: TVaultItem): ReactElemen
 						'border-regularText/15 bg-regularText/5 col-span-3 flex cursor-alias items-center justify-start overflow-hidden rounded-xl border p-3'
 					}>
 					<ImageWithFallback
-						src={`https://assets.smold.app/tokens/${vault.chainID}/${vault.token.address}/logo-32.png`}
-						altSrc={`/tokens/${vault.token.address.toLowerCase()}/logo-32.png`}
+						src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${vault.chainID}/${vault.token.address.toLowerCase()}/logo-32.png`}
+						altSrc={`/tokens/${vault.token.symbol}/logo-32.png`}
 						alt={vault.token.symbol}
 						width={28}
 						height={28}
@@ -427,8 +427,8 @@ export const VaultItem = ({vault, price, options, apr}: TVaultItem): ReactElemen
 						'border-regularText/15 bg-regularText/5 flex w-full items-center rounded-xl border px-2.5 py-2'
 					}>
 					<ImageWithFallback
-						src={`https://assets.smold.app/tokens/${vault.chainID}/${vault.token.address}/logo-32.png`}
-						altSrc={`/tokens/${vault.token.address.toLowerCase()}/logo-32.png`}
+						src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${vault.chainID}/${vault.token.address.toLowerCase()}/logo-32.png`}
+						altSrc={`/tokens/${vault.token.symbol}/logo-32.png`}
 						alt={vault.token.symbol}
 						width={28}
 						height={28}

--- a/packages/katana/components/WETHTokenAmountInput.tsx
+++ b/packages/katana/components/WETHTokenAmountInput.tsx
@@ -169,7 +169,7 @@ export function WETHTokenAmountInput(props: TWETHTokenAmountInputProps): ReactEl
 								'border-regularText/15 bg-regularText/5 relative flex !h-16 items-center gap-x-1 rounded-lg border px-4 py-3'
 							}>
 							<ImageWithFallback
-								src={`https://assets.smold.app/tokens/${vault.chainID}/${selectedToken?.address === ETH_ADDRESS ? WETH_ADDRESS : selectedToken?.address}/logo-128.png`}
+								src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${vault.chainID}/${selectedToken?.address === ETH_ADDRESS ? WETH_ADDRESS.toLowerCase() : selectedToken?.address.toLowerCase()}/logo-32.png`}
 								alt={selectedToken?.symbol || 'token'}
 								width={32}
 								height={32}
@@ -193,7 +193,7 @@ export function WETHTokenAmountInput(props: TWETHTokenAmountInputProps): ReactEl
 												'hover:bg-regularText/5 flex w-full items-center gap-x-2 rounded-lg p-2'
 											}>
 											<ImageWithFallback
-												src={`https://assets.smold.app/tokens/${vault.chainID}/${token.address === ETH_ADDRESS ? WETH_ADDRESS : token.address}/logo-128.png`}
+												src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${vault.chainID}/${token.address === ETH_ADDRESS ? WETH_ADDRESS.toLowerCase() : token.address.toLowerCase()}/logo-32.png`}
 												alt={token.symbol}
 												width={24}
 												height={24}

--- a/packages/lib/components/common/TokenAmountInput.tsx
+++ b/packages/lib/components/common/TokenAmountInput.tsx
@@ -48,7 +48,7 @@ export function TokenAmountInput(props: TTokenAmountInputProps): ReactElement {
 						'border-regularText/15 bg-regularText/5 relative flex !h-16 items-center gap-x-2 rounded-lg border px-4 py-3 disabled:cursor-not-allowed'
 					}>
 					<ImageWithFallback
-						src={`https://assets.smold.app/tokens/${chainID}/${configuration?.tokenToSpend.token?.address}/logo-128.png`}
+						src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${chainID}/${configuration?.tokenToSpend.token?.address.toLowerCase()}/logo-32.png`}
 						alt={configuration?.tokenToSpend.token?.address || 'address'}
 						width={32}
 						height={32}

--- a/packages/lib/components/common/TokenSelector.tsx
+++ b/packages/lib/components/common/TokenSelector.tsx
@@ -122,7 +122,7 @@ export function TokenSelector({
 					'border-regularText/15 bg-regularText/5 relative flex !h-16 items-center gap-x-1 rounded-lg border px-4 py-3 disabled:cursor-not-allowed'
 				}>
 				<ImageWithFallback
-					src={`https://assets.smold.app/tokens/${chainID}/${configuration?.tokenToSpend.token?.address}/logo-128.png`}
+					src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${chainID}/${configuration?.tokenToSpend.token?.address.toLowerCase()}/logo-32.png`}
 					alt={configuration?.tokenToSpend.token?.address || 'address'}
 					width={32}
 					height={32}

--- a/packages/lib/components/common/TokenSelectorDropdown.tsx
+++ b/packages/lib/components/common/TokenSelectorDropdown.tsx
@@ -68,7 +68,7 @@ function TokenItem(props: {item: TToken; onSelected: (token: TToken) => void}): 
 			<div className={'flex gap-x-4'}>
 				<div className={'flex items-center'}>
 					<ImageWithFallback
-						src={`https://assets.smold.app/tokens/${props.item.chainID}/${props.item.address}/logo-128.png`}
+						src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${props.item.chainID}/${props.item.address.toLowerCase()}/logo-32.png`}
 						alt={props.item.name}
 						width={32}
 						height={32}

--- a/packages/lib/components/common/VaultItem.tsx
+++ b/packages/lib/components/common/VaultItem.tsx
@@ -241,7 +241,7 @@ export const VaultItem = ({vault, price, options}: TVaultItem): ReactElement => 
 						'border-regularText/15 bg-regularText/5 col-span-2 flex cursor-alias items-center justify-start overflow-hidden rounded-xl border p-3'
 					}>
 					<ImageWithFallback
-						src={`https://assets.smold.app/tokens/${vault.chainID}/${vault.token.address}/logo-32.png`}
+						src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${vault.chainID}/${vault.token.address.toLowerCase()}/logo-32.png`}
 						alt={vault.token.symbol}
 						width={28}
 						height={28}
@@ -312,7 +312,7 @@ export const VaultItem = ({vault, price, options}: TVaultItem): ReactElement => 
 						'border-regularText/15 bg-regularText/5 flex w-full items-center rounded-xl border px-2.5 py-2'
 					}>
 					<ImageWithFallback
-						src={`https://assets.smold.app/tokens/${vault.chainID}/${vault.token.address}/logo-32.png`}
+						src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${vault.chainID}/${vault.token.address.toLowerCase()}/logo-32.png`}
 						alt={vault.token.symbol}
 						width={28}
 						height={28}

--- a/packages/lib/components/common/VaultLink.tsx
+++ b/packages/lib/components/common/VaultLink.tsx
@@ -21,7 +21,7 @@ export const VaultLink = (props: TVaultLinkProps): ReactElement => (
 		}>
 		<div className={'flex w-full cursor-alias items-center'}>
 			<ImageWithFallback
-				src={`https://assets.smold.app/tokens/${props.vault.chainID}/${props.vault.token.address}/logo-32.png`}
+				src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${props.vault.chainID}/${props.vault.token.address.toLowerCase()}/logo-32.png`}
 				alt={props.vault.token.symbol}
 				width={28}
 				height={28}

--- a/packages/lib/components/common/WithdrawModal.tsx
+++ b/packages/lib/components/common/WithdrawModal.tsx
@@ -256,7 +256,7 @@ function OutputComponent(props: {isReady: boolean; availableBalance: TNormalized
 					)}>
 					<div className={'flex w-full items-center gap-x-2'}>
 						<ImageWithFallback
-							src={`https://assets.smold.app/tokens/${configuration?.vault?.chainID}/${configuration?.tokenToReceive.token?.address}/logo-128.png`}
+							src={`https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/${configuration?.vault?.chainID}/${configuration?.tokenToReceive.token?.address.toLowerCase()}/logo-32.png`}
 							alt={configuration?.tokenToReceive.token?.address || 'address'}
 							width={32}
 							height={32}

--- a/packages/lib/next.config.js
+++ b/packages/lib/next.config.js
@@ -25,6 +25,10 @@ module.exports = withPlausibleProxy({
 				},
 				{
 					protocol: 'https',
+					hostname: 'cdn.jsdelivr.net'
+				},
+				{
+					protocol: 'https',
 					hostname: 'assets.smold.app'
 				},
 				{

--- a/packages/lib/public/tokens/manualTokens.json
+++ b/packages/lib/public/tokens/manualTokens.json
@@ -14,7 +14,7 @@
 			"address": "0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a",
 			"name": "Agora USD",
 			"symbol": "AUSD",
-			"logoURI": "https://assets.smold.app/api/token/1/0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a/logo-128.png",
+			"logoURI": "https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/1/0x00000000efe302beaa2b3e6e1b18d08d69a9012a/logo-128.png",
 			"chainId": 747474,
 			"decimals": 6
 		}


### PR DESCRIPTION
- Update all image links to use https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/... as the image CDN. Requires lowercasing the address. 
- update backup route to /public to correctly fetch those images if needed.
- update next.config.js to include jsdelivr
- use 32px images instead of 128px when larger sizes are not needed. 