### PR TITLE
fix missing KAT rewards in modal and clean up modal text and sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tsconfig.tsbuildinfo
 **/workbox-*.js
 **/workbox-*.js.map
 **/worker-*.js.map
+
+# AI folders
+.codex

--- a/packages/katana/components/AprModal.tsx
+++ b/packages/katana/components/AprModal.tsx
@@ -18,8 +18,7 @@ type TAprModal = {
 
 export function AprModal({isOpen, onClose, vault, apr, steerRewardPoints}: TAprModal): ReactElement {
 	const katanaAppRewardsAPR = apr?.katanaAppRewardsAPR || 0;
-	const fixedRateKatanRewardsAPR = apr?.FixedRateKatanaRewards || 0;
-	const katanaBonusAPR = apr?.katanaBonusAPY || 0;
+	const fixedRateKatanaRewardsAPR = apr?.fixedRateKatanaRewards || 0;
 	const katanaNativeYield = apr?.katanaNativeYield || 0;
 
 	// Exclude legacy katanaRewardsAPR and non-APR steerPointsPerDollar from totals
@@ -81,9 +80,19 @@ export function AprModal({isOpen, onClose, vault, apr, steerRewardPoints}: TAprM
 								/>
 								<span className={'text-[14px] font-medium text-white'}>{'Base Rewards APR'}</span>
 							</div>
-							<span className={'text-[14px] text-white'}>{toPercent(fixedRateKatanRewardsAPR)}</span>
+							<span className={'text-[14px] text-white'}>{toPercent(fixedRateKatanaRewardsAPR)}</span>
 						</div>
 						<p className={'text-left text-[12px] text-white/60'}>{'Limited time fixed KAT rewards'}</p>
+						<p className={'text-left text-[12px] text-white/60'}>
+							{'* claimable after 28 days, subject to '}
+							<a
+								href={'https://x.com/katana/status/1961475531188126178'}
+								target={'_blank'}
+								rel={'noopener noreferrer'}
+								className={'text-accentText underline'}>
+								{'haircut schedule.'}
+							</a>
+						</p>
 					</div>
 
 					<div className={'flex flex-col gap-1'}>
@@ -102,25 +111,6 @@ export function AprModal({isOpen, onClose, vault, apr, steerRewardPoints}: TAprM
 						</div>
 						<p className={'text-left text-[12px] text-white/60'}>
 							{'KAT Rewards passed through from Apps'}
-						</p>
-					</div>
-
-					<div className={'flex flex-col gap-1'}>
-						<div className={'flex items-center justify-between'}>
-							<div className={'flex items-center gap-[10px]'}>
-								<Image
-									src={'/tokens/KAT/logo.jpg'}
-									alt={'KAT'}
-									className={'size-5 rounded-full'}
-									width={20}
-									height={20}
-								/>
-								<span className={'text-[14px] font-medium text-white/60'}>{'Deposit Bonus APR'}</span>
-							</div>
-							<span className={'text-[14px] text-white/60'}>{toPercent(katanaBonusAPR)}</span>
-						</div>
-						<p className={'text-left text-[12px] text-white/60'}>
-							{'Applied if you deposited before Sept. 1st and hold for 90 days'}
 						</p>
 					</div>
 				</div>
@@ -158,7 +148,11 @@ export function AprModal({isOpen, onClose, vault, apr, steerRewardPoints}: TAprM
 						className={
 							'list-inside list-disc space-y-1 text-left text-[12px] font-medium leading-[1.21] text-white/50'
 						}>
-						<li>{'KAT tokens are locked until no later than Feb. 20 2026.'}</li>
+						<li>
+							{
+								'KAT tokens are locked until TGE, which is now targeted to occur on or before the end of March 2026.'
+							}
+						</li>
 						<li>{'KAT APR is calculated using an assumed $1B Fully Diluted Valuation.'}</li>
 					</ul>
 					<p className={'mt-2 text-left text-[12px] font-medium leading-[1.21] text-white/50'}>

--- a/packages/katana/hooks/useKatanaAprs.test.ts
+++ b/packages/katana/hooks/useKatanaAprs.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, it} from 'vitest';
+
+import {normalizeKatanaAprs} from './useKatanaAprs';
+
+describe('normalizeKatanaAprs', () => {
+	it('keeps the live fixed-rate rewards field name', () => {
+		const normalizedAprs = normalizeKatanaAprs({
+			'0xvault': {
+				apr: {
+					netAPR: 0.4039060922646386,
+					extra: {
+						stakingRewardsAPR: null,
+						gammaRewardAPR: null,
+						katanaRewardsAPR: 0.036415935103465066,
+						katanaAppRewardsAPR: 0.036415935103465066,
+						fixedRateKatanaRewards: 0.35,
+						katanaBonusAPY: 0.068,
+						katanaNativeYield: 0.03390609226463859,
+						steerPointsPerDollar: 0.18
+					}
+				}
+			}
+		});
+
+		expect(normalizedAprs['0xvault']?.apr.extra.fixedRateKatanaRewards).toBe(0.35);
+		expect(normalizedAprs['0xvault']?.apr.extra).not.toHaveProperty('FixedRateKatanaRewards');
+	});
+
+	it('maps the legacy fixed-rate rewards field without double counting it', () => {
+		const normalizedAprs = normalizeKatanaAprs({
+			'0xvault': {
+				apr: {
+					netAPR: 0.18687250816600576,
+					extra: {
+						stakingRewardsAPR: null,
+						gammaRewardAPR: null,
+						katanaRewardsAPR: 0.022714370298222892,
+						katanaAppRewardsAPR: 0.022714370298222892,
+						FixedRateKatanaRewards: 0.14,
+						katanaBonusAPY: 0.016,
+						katanaNativeYield: 0.02415813786778287,
+						steerPointsPerDollar: 0.1546
+					}
+				}
+			}
+		});
+
+		const normalizedExtra = normalizedAprs['0xvault']!.apr.extra;
+		const totalAPR =
+			normalizedExtra.stakingRewardsAPR +
+			normalizedExtra.gammaRewardAPR +
+			normalizedExtra.katanaAppRewardsAPR +
+			normalizedExtra.fixedRateKatanaRewards +
+			normalizedExtra.katanaNativeYield;
+
+		expect(normalizedAprs['0xvault']?.apr.extra.fixedRateKatanaRewards).toBe(0.14);
+		expect(totalAPR).toBeCloseTo(0.18687250816600576);
+	});
+});

--- a/packages/katana/hooks/useKatanaAprs.ts
+++ b/packages/katana/hooks/useKatanaAprs.ts
@@ -14,17 +14,77 @@ export type TKatanaAprs = {
 };
 
 export type TAprData = {
+	stakingRewardsAPR: number;
+	gammaRewardAPR: number;
 	katanaRewardsAPR: number; // legacy field for App rewards from Morpho, Sushi, Yearn, etc.
 	katanaAppRewardsAPR: number; // rewards from Morpho, Sushi, Yearn, etc.
-	FixedRateKatanaRewards: number; // fixed rate rewards from Katana
+	fixedRateKatanaRewards: number; // fixed rate rewards from Katana
 	katanaBonusAPY: number; // bonus APR from Katana for not leaving the vault
 	katanaNativeYield: number; // yield from katana markets (the netAPR). This is subsidized if low.
 	steerPointsPerDollar?: number; // points per dollar from APR oracle (metadata, not part of APR sum)
 };
 
 type TCacheData = {
-	data: TKatanaAprs;
+	data: Partial<TKatanaAprs>;
 	timestamp: number;
+};
+
+type TRawAprData = {
+	stakingRewardsAPR?: number | null;
+	gammaRewardAPR?: number | null;
+	katanaRewardsAPR?: number | null;
+	katanaAppRewardsAPR?: number | null;
+	fixedRateKatanaRewards?: number | null;
+	FixedRateKatanaRewards?: number | null;
+	katanaBonusAPY?: number | null;
+	katanaNativeYield?: number | null;
+	steerPointsPerDollar?: number | null;
+};
+
+type TRawKatanaAprs = {
+	[key: string]: {
+		apr: {
+			netAPR: number;
+			extra: TRawAprData;
+		};
+	};
+};
+
+const getNumberOrZero = (value: number | null | undefined): number => {
+	return typeof value === 'number' ? value : 0;
+};
+
+export const normalizeAprData = (aprData?: TRawAprData): TAprData => {
+	return {
+		stakingRewardsAPR: getNumberOrZero(aprData?.stakingRewardsAPR),
+		gammaRewardAPR: getNumberOrZero(aprData?.gammaRewardAPR),
+		katanaRewardsAPR: getNumberOrZero(aprData?.katanaRewardsAPR),
+		katanaAppRewardsAPR: getNumberOrZero(aprData?.katanaAppRewardsAPR),
+		fixedRateKatanaRewards: getNumberOrZero(
+			aprData?.fixedRateKatanaRewards ?? aprData?.FixedRateKatanaRewards
+		),
+		katanaBonusAPY: getNumberOrZero(aprData?.katanaBonusAPY),
+		katanaNativeYield: getNumberOrZero(aprData?.katanaNativeYield),
+		steerPointsPerDollar: getNumberOrZero(aprData?.steerPointsPerDollar)
+	};
+};
+
+export const normalizeKatanaAprs = (aprData: Partial<TRawKatanaAprs>): Partial<TKatanaAprs> => {
+	return Object.entries(aprData).reduce<Partial<TKatanaAprs>>((accumulator, [vaultAddress, vaultData]) => {
+		if (!vaultData) {
+			return accumulator;
+		}
+
+		accumulator[vaultAddress] = {
+			...vaultData,
+			apr: {
+				...vaultData.apr,
+				extra: normalizeAprData(vaultData.apr.extra)
+			}
+		};
+
+		return accumulator;
+	}, {});
 };
 
 export const useKatanaAprs = (): {data: Partial<TKatanaAprs>; isLoading: boolean; error: Error | null} => {
@@ -40,10 +100,11 @@ export const useKatanaAprs = (): {data: Partial<TKatanaAprs>; isLoading: boolean
 				if (cachedString) {
 					const cached: TCacheData = JSON.parse(cachedString);
 					const now = Date.now();
+					const normalizedCachedData = normalizeKatanaAprs(cached.data);
 
 					// Return cached data if within TTL
 					if (now - cached.timestamp < CACHE_TTL) {
-						set_data(cached.data);
+						set_data(normalizedCachedData);
 						set_isLoading(false);
 						return;
 					}
@@ -53,7 +114,7 @@ export const useKatanaAprs = (): {data: Partial<TKatanaAprs>; isLoading: boolean
 				if (!apiUrl) {
 					throw new Error('KATANA_APR_SERVICE_API environment variable is not set');
 				}
-				const freshData = await axios.get(apiUrl).then(res => res.data);
+				const freshData = await axios.get(apiUrl).then(res => normalizeKatanaAprs(res.data));
 
 				const cacheData: TCacheData = {
 					data: freshData,
@@ -68,7 +129,7 @@ export const useKatanaAprs = (): {data: Partial<TKatanaAprs>; isLoading: boolean
 				const cachedString = localStorage.getItem(CACHE_KEY);
 				if (cachedString) {
 					const cached: TCacheData = JSON.parse(cachedString);
-					set_data(cached.data);
+					set_data(normalizeKatanaAprs(cached.data));
 				}
 			} finally {
 				set_isLoading(false);


### PR DESCRIPTION
This change proposes and update to the APY modals for the katana APP. The fixed rewards were not being piped in correctly due to a variable name, and the text was not updated to match the current expected TGE date for KAT.

Now fixed.

before: 
<img width="415" height="557" alt="image" src="https://github.com/user-attachments/assets/d70af7e5-6b4a-43ad-a918-4acbcc178e4d" />

After: 
<img width="403" height="532" alt="image" src="https://github.com/user-attachments/assets/aafed937-81fd-4a4e-9703-0aa59d431c06" />
