### PR TITLE
Remove katana haircut text

### DIFF
--- a/packages/katana/components/AprModal.tsx
+++ b/packages/katana/components/AprModal.tsx
@@ -83,16 +83,6 @@ export function AprModal({isOpen, onClose, vault, apr, steerRewardPoints}: TAprM
 							<span className={'text-[14px] text-white'}>{toPercent(fixedRateKatanaRewardsAPR)}</span>
 						</div>
 						<p className={'text-left text-[12px] text-white/60'}>{'Limited time fixed KAT rewards'}</p>
-						<p className={'text-left text-[12px] text-white/60'}>
-							{'* claimable after 28 days, subject to '}
-							<a
-								href={'https://x.com/katana/status/1961475531188126178'}
-								target={'_blank'}
-								rel={'noopener noreferrer'}
-								className={'text-accentText underline'}>
-								{'haircut schedule.'}
-							</a>
-						</p>
 					</div>
 
 					<div className={'flex flex-col gap-1'}>

--- a/packages/katana/components/AprModal.tsx
+++ b/packages/katana/components/AprModal.tsx
@@ -111,50 +111,33 @@ export function AprModal({isOpen, onClose, vault, apr, steerRewardPoints}: TAprM
 						<span className={'text-[16px] font-bold text-white'}>{'Expected Net APR'}</span>
 						<span className={'text-[16px] font-bold text-white'}>{toPercent(totalAPR)}</span>
 					</div>
-					{steerRewardPoints !== undefined && steerRewardPoints > 0 && (
-						<div>
-							<p className={'text-regularText text-left text-sm leading-relaxed'}>
-								{'This vault earns '}
-								{formatAmount(steerRewardPoints, 2, 2)}
-								{' Steer Points / dollar deposited,'}
-							</p>
-							<p className={'text-regularText text-left text-sm leading-relaxed'}>
-								{'but you must '}
-								<a
-									className={'text-accentText underline'}
-									href={'https://app.steer.finance/points'}
-									target={'_blank'}
-									rel={'noreferrer'}>
-									{'register here to earn them'}
-								</a>
-								{'.'}
-							</p>
-						</div>
-					)}
 				</div>
 
 				<div className={'rounded-[12px] px-4 pb-4 pt-2'}>
-					<ul
-						className={
-							'list-inside list-disc space-y-1 text-left text-[12px] font-medium leading-[1.21] text-white/50'
-						}>
-						<li>
-							{
-								'KAT tokens are locked until TGE, which is now targeted to occur on or before the end of March 2026.'
-							}
-						</li>
-						<li>{'KAT APR is calculated using an assumed $1B Fully Diluted Valuation.'}</li>
-					</ul>
 					<p className={'mt-2 text-left text-[12px] font-medium leading-[1.21] text-white/50'}>
 						{'Read more about KAT tokenomics '}
 						<a
 							href={'https://katana.network/blog/the-network-is-katana-the-token-is-kat'}
 							target={'_blank'}
 							rel={'noopener noreferrer'}
-							className={'text-blue-400 underline hover:text-blue-300'}>
+							className={'text-accentText underline'}>
 							{'here'}
 						</a>
 					</p>
+					{steerRewardPoints !== undefined && steerRewardPoints > 0 && (
+						<div>
+							<p className={'mt-2 text-left text-[12px] font-medium leading-[1.21] text-white/50'}>
+								{'The Steer Points program has concluded. '}
+								<a
+									className={'text-accentText underline'}
+									href={'https://app.steer.finance/points'}
+									target={'_blank'}
+									rel={'noreferrer'}>
+									{'You can view your Steer Points here.'}
+								</a>
+							</p>
+						</div>
+					)}
 				</div>
 			</div>
 		</ModalWrapper>

--- a/packages/katana/components/AprModal.tsx
+++ b/packages/katana/components/AprModal.tsx
@@ -2,7 +2,6 @@ import {type ReactElement} from 'react';
 import Image from 'next/image';
 import {ModalWrapper} from '@lib/components/common/ModalWrapper';
 import {IconCross} from '@lib/components/icons/IconCross';
-import {formatAmount} from '@lib/utils';
 import {toPercent} from '@lib/utils/tools';
 
 import type {TYDaemonVault} from '@lib/hooks/useYearnVaults.types';

--- a/packages/katana/next-env.d.ts
+++ b/packages/katana/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/packages/lib/hooks/useYearnVaults.ts
+++ b/packages/lib/hooks/useYearnVaults.ts
@@ -29,7 +29,7 @@ const kongVaultSchema = z
 			.nullable()
 			.default(null),
 		tvl: z.number().nullable().default(0),
-		pricePerShare: z.union([z.string(), z.number()]).default('0'),
+		pricePerShare: z.preprocess(value => value ?? '0', z.union([z.string(), z.number()]).default('0')),
 		performance: z
 			.object({
 				oracle: z
@@ -252,19 +252,19 @@ function matchesFilter(vault: TKongVault, filter: TPossibleVaultFilter): boolean
 	const inc = vault.inclusion;
 	switch (filter) {
 		case 'katana':
-			return inc?.isKatana === true;
+			return Boolean(inc?.isKatana);
 		case 'morpho':
-			return inc?.isMorpho === true;
+			return Boolean(inc?.isMorpho);
 		case 'juiced':
-			return inc?.isYearnJuiced === true;
+			return Boolean(inc?.isYearnJuiced);
 		case 'gimme':
-			return inc?.isGimme === true;
+			return Boolean(inc?.isGimme);
 		case 'pooltogether':
-			return inc?.isPoolTogether === true;
+			return Boolean(inc?.isPoolTogether);
 		case 'v3':
-			return vault.v3 === true;
+			return vault.v3;
 		case 'v2':
-			return vault.v3 !== true;
+			return !vault.v3;
 		case 'retired':
 			return vault.isRetired;
 		case 'all':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,8 +62,8 @@
 		"theme.config.js",
 		".eslintrc.js",
 		".next/types/**/*.ts",
-		"stylelint.config",
-		"commitlint.config",
+		"stylelint.config.js",
+		"commitlint.config.js",
 		"packages/pendle/constants.ts",
 		"packages/pendle/constants.ts"
 	]


### PR DESCRIPTION
This PR makes the following changes:

- Removes Katana specific text about a haircut schedule that is no longer active.
- Updates text about the Steer points program.
- fixes zod issues due to changes with kong.

see https://github.com/yearn/yearn.fi/pull/1212 for more info about the haircut schedule change.

To test: `bun run dev:katana`
- APY modal should not include haircut info and should match the message about Steer. And no runtime errors

<img width="516" height="550" alt="image" src="https://github.com/user-attachments/assets/88c5ece3-c9c6-436b-859b-c0762ab6c783" />
